### PR TITLE
fixed issue when steam library is not under .steam

### DIFF
--- a/protontricks
+++ b/protontricks
@@ -157,7 +157,10 @@ def get_proton_dir(steam_lib_dirs, proton_version):
     preferring the `proton_version` version of Proton
     """
     for path in steam_lib_dirs:
-        dirs = os.listdir(os.path.join(path, "steamapps", "common"))
+        try:
+            dirs = os.listdir(os.path.join(path, "steamapps", "common"))
+        except FileNotFoundError:
+            continue
 
         for app_name in dirs:
             if "Proton" in app_name:


### PR DESCRIPTION
when installing all games outside the steam application folder, the common folder is created only in the steam library folder and not in the .steam folder, raising a FileNotFound error when looking for it first in the .steam folder.
added a try\except clause to continue searching in the next path in steam_lib_dirs if can't find common in the first path.