### PR TITLE
Fix PROTON_VERSION

### DIFF
--- a/protontricks
+++ b/protontricks
@@ -232,10 +232,10 @@ if __name__ == "__main__":
                   "automatically and $PROTON_VERSION wasn't set")
             sys.exit(-1)
     else:
+        proton_version = os.environ.get("PROTON_VERSION")
         print("[INFO] Using preferred Proton installation {}".format(
             proton_version
         ))
-        proton_version = os.environ.get("PROTON_VERSION")
 
 
     proton_dir = get_proton_dir(


### PR DESCRIPTION
A silly mistake, but it was making `PROTON_VERSION` unusable. With this being fixed, people can use `PROTON_VERSION` as a workaround to #24, until it gets fixed:

```
$ export PROTON_VERSION='Proton 3.16'
$ protontricks 489830 xact
```