### PR TITLE
Skip corrupted manifest files

### DIFF
--- a/protontricks
+++ b/protontricks
@@ -81,9 +81,13 @@ class SteamApp(object):
         """
         Parse appmanifest_X.acf file containing Steam app installation metadata
         and return a SteamApp object
+        Ignore corrupted manifest files
         """
         with open(path, "r") as f:
-            content = f.read()
+            try:
+                content = f.read()
+            except:
+                return None
 
         # App manifest may be completely empty for some reason.
         # In that case, skip it


### PR DESCRIPTION
Corrupted manifest file currently cause the Python file parser
to choke, leading to an unhandled exception e.g.:

    Traceback (most recent call last):
    File "/usr/bin/protontricks", line 310, in <module>
      steam_apps = get_steam_apps(steam_lib_dirs)
    File "/usr/bin/protontricks", line 250, in get_steam_apps
      steam_app = SteamApp.from_appmanifest(path)
    File "/usr/bin/protontricks", line 86, in from_appmanifest
      content = f.read()
    File "/usr/lib/python-exec/python3.6/../../../lib64/python3.6/codecs.py", line 321, in decode
      (result, consumed) = self._buffer_decode(data, self.errors, final)

Signed-off-by: Rob Walker <bob.mt.wya@gmail.com>