### PR TITLE
Adds GUI feature requested in #15

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ protontricks -s <GAME NAME>
 
 # Run winetricks for the game
 protontricks <APPID> <ACTIONS>
+
+# Run the protontricks GUI
+protontricks gui
 ```
 
 Since this is a wrapper, all syntax that works for Winetricks will potentially work for Protontricks.

--- a/protontricks
+++ b/protontricks
@@ -360,6 +360,22 @@ if __name__ == "__main__":
         os.environ["WINESERVER"] = os.path.join(
             proton_app.install_path, "dist", "bin", "wineserver")
 
+    if sys.argv[1].lower() == "gui":
+        combo_values = "|".join([f'{app.name}: {app.appid}' for app in steam_apps])
+        try:
+            choice = subprocess.check_output(['zenity', '--forms', '--text=Steam Game Library',
+                                              '--title=Choose Game', '--add-combo', 'Pick a library game',
+                                              '--combo-values', combo_values])
+            choice_id = str(choice).rsplit(':')[-1]
+            choice_id = ''.join(x for x in choice_id if x.isdigit())
+            sys.argv = [sys.argv[0], choice_id, '--gui']
+
+        except subprocess.CalledProcessError:
+            print("Zenity returned an error or cancel was clicked")
+            sys.exit(0)
+        except OSError:
+            print("Zenity was not found")
+
     if sys.argv[1] == "-s":
         # Search for games
         search_query = " ".join(sys.argv[2:])


### PR DESCRIPTION
This pull request adds a [GUI using zenity](https://imgur.com/a/WZPB3YS) to protontricks. Zenity is typically a requirement for winetricks and is likely to be installed.

The combo box dialog lists all the games from `steam_apps`. When one is selected, protontricks continues normally with the argument `--gui` which starts the builtin winetricks GUI.